### PR TITLE
fix(typings): update types path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lib",
     "LICENSE"
   ],
-  "types": "./lib/index.d.ts",
+  "types": "./lib/src/index.d.ts",
   "scripts": {
     "build": "rimraf ./lib && mkdirp ./lib && tsc",
     "prepare": "npm run build",


### PR DESCRIPTION
This PR updates the `types` location so typescript can correctly make use of typings. 