### PR TITLE
Optimize by filtering grants by action and resource early

### DIFF
--- a/test/acl.spec.ts
+++ b/test/acl.spec.ts
@@ -127,7 +127,7 @@ describe('Test Suite: Access Control', function () {
                 condition: categorySportsCondition
             }]
         }
-    }
+    };
 
     beforeEach(function () {
         this.ac = new AccessControl();


### PR DESCRIPTION
- When checking for granted resources, actions, or attributes, the current code
  executes all conditions for all grants, and then filters the passed ones
  by action and/or resource in the query.
- This is inefficient, especially if the condition checks are expensive, e.g.
  if they make database calls.
- I've optimized it by first filtering out grants based on the action and
  resource in the query, and then running the condition checks on the remaining.