### PR TITLE
Fix CommonUtil.clone breaking function's scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,21 @@
       "integrity": "sha512-vw3VyFPa9mlba6NZPBZC3q2Zrnkgy5xuCVI43/tTLX6umdYrYvcFtQUKi2zH3PjFZQ9XCxNM/NMrM9uk8TPOzg==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
+    },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
+      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/matcher": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/matcher/-/matcher-1.1.0.tgz",
@@ -2686,6 +2701,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "homepage": "https://github.com/tensult/role-acl#readme",
   "devDependencies": {
     "@types/jasmine": "^3.3.0",
+    "@types/lodash.clonedeep": "^4.5.6",
     "@types/matcher": "^1.1.0",
     "@types/node": "^9.4.7",
     "handlebars": "^4.4.0",
@@ -67,6 +68,7 @@
   },
   "dependencies": {
     "jsonpath-plus": "^0.18.0",
+    "lodash.clonedeep": "^4.5.0",
     "matcher": "^1.0.0",
     "notation": "^1.3.5"
   }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,8 +1,9 @@
-import * as Notation from 'notation';
-import * as Matcher from 'matcher';
+import Notation from 'notation';
+import Matcher from 'matcher';
 import { ArrayUtil } from './array';
 import { ConditionUtil } from '../conditions';
 import { AccessControlError, IQueryInfo, IAccessInfo, ICondition } from '../core';
+import cloneDeep from 'lodash.clonedeep';
 
 export class CommonUtil {
 
@@ -42,7 +43,7 @@ export class CommonUtil {
     }
 
     public static clone(o: any): object {
-        return CommonUtil.fromExtendedJSON(CommonUtil.toExtendedJSON(o));
+        return cloneDeep(o);
     }
 
     public static type(o: any): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "declarationDir": "./lib",
         "target": "es5",
         "module": "commonjs",
+        "esModuleInterop": true,
         "moduleResolution": "node",
         "removeComments": false,
         "noLib": false,


### PR DESCRIPTION
My teammates were trying to use functions to control permissions, but they stuck into an error because their functions have lost access to the module scope where they were declared.

```js
const isAllowed = ({ role }) => RoleEnum.ADMIN === role;
//=> throws Cannot read property "ADMIN" of undefined.
```

The error is caused when `fromExtendedJSON` is called inside `clone` with `toExtendedJSON` result and function is re-created and don't have access to the module scope where they were declared anymore.

https://github.com/tensult/role-acl/blob/dd60737a080274bdf7b6b5cb45afc9d6faf4c4e6/src/utils/common.ts#L38

So, I replaced this logic with `lodash.cloneDeep` function and it deep clones the objects without re-creating functions and causing that issue.

#### Changes
- Added `"esModuleInterop"` to `tsconfig.json`, to support ESM without `import * as ` syntax.
- Installed `lodash.clonedeep` and its types (`@types/lodash.clonedeep`).
- Replaced `CommonUtil.clone` logic with `to/fromExtendedJSON` to `cloneDeep` function.