### PR TITLE
Add custom conditions use cases to the docs

### DIFF
--- a/src/conditions/util.ts
+++ b/src/conditions/util.ts
@@ -160,3 +160,6 @@ export class ConditionUtil {
     return valuePathOrValue;
   }
 }
+
+// Expose getValueByPath only as public API
+export const getValueByPath = ConditionUtil.getValueByPath;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './AccessControl';
 export * from './core';
+export { getValueByPath } from './conditions/util';


### PR DESCRIPTION
Details  
- Add custom conditions use cases to the docs
- Add tests for corresponding examples
- Add version requirements for every use case in the documentation
- Propose unified terminology to avoid confusion:  
`core condition`: `AND`, `OR`. `NOT`, etc
`custom condition`: declared and registered custom condition `conditionName`, available in the grand  flow as `custom:conditionName`  
`function condition`: native JS function, added while defining the grands, not serializeable
- Expose `getValueByPath` from condition utils to allow developers to use JSONPath in their custom condition implementations. It's not exposed in the browser build (`./app.js`), but I'm not sure how it'll affect the bundle size.

Ref: #45 